### PR TITLE
Implement Evidence schema

### DIFF
--- a/src/modules/users/evidenceLog.schema.js
+++ b/src/modules/users/evidenceLog.schema.js
@@ -1,0 +1,50 @@
+import mongoose, { Schema } from "mongoose";
+
+const EvidenceSchema = new mongoose.Schema(
+  {
+    practice_log_id: {
+      required: true,
+      type: Schema.Types.ObjectId,
+      ref: "Practice",
+    },
+    user_id: {
+      type: Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+    },
+    type: {
+      enum: ["file", "link", "note"],
+      required: true,
+    },
+    uri: {
+      type: String,
+      required: function () {
+        return this.type === "file" || this.type === "link";
+      },
+    },
+    note: {
+      type: String,
+      required: function () {
+        return this.type === "note";
+      },
+    },
+    metadata: { type: Object },
+  },
+  { timestamps: true }
+);
+
+EvidenceSchema.pre("validate", function (next) {
+  if (this.type === "note" && !this.note) {
+    return next(new Error("Text is required for note type"));
+  }
+
+  if ((this.type === "file" || this.type === "link") && !this.uri) {
+    return next(new Error("URL is required for file or link type"));
+  }
+
+  next();
+});
+
+const evidenceModel = mongoose.model("Evidence", EvidenceSchema);
+
+export default evidenceModel;


### PR DESCRIPTION
This pull request implements the Evidence schema according to the Evidence.md documentation.

Planned Implementation:
- Create Evidence schema in the models folder
- Include core fields: practice_log_id, user_id, type, uri, note, metadata
- Define relationships to Practice Logs and Users
- Enforce validation rules based on evidence type
- Use timestamps for lifecycle tracking

Objectives:
- Allow users to attach optional proof to practice sessions
- Ensure evidence always belongs to a valid practice log
- Keep the schema lean by storing references and metadata only
- Enforce strict ownership and access rules

Deliverables / Next Steps:
- Add API endpoints for evidence CRUD operations
- Define storage provider for file uploads
- Enforce configurable limits per practice log
- Integrate signed URLs for secure file access
